### PR TITLE
LPS-75418 Fix dependencies

### DIFF
--- a/analytics-data-binding-impl/build.gradle
+++ b/analytics-data-binding-impl/build.gradle
@@ -2,9 +2,10 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-	provided group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.8.3"
-	provided group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.8.3"
-	provided group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.8.3"
+	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.8.3"
+	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.8.3"
+	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.8.3"
+
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":apps:analytics:analytics-api")
 


### PR DESCRIPTION
Package jackson dependencies all together. Bundle was being left to unresolved state in the portal.

```
g! lb | grep Analytics
  677|Active     |   10|Liferay Analytics API (1.0.0)
  678|Installed  |   10|Liferay Analytics Data Binding Implementation (1.0.0)
  679|Active     |   10|Liferay Analytics Java Client Implementation (1.0.0)
true
g! diag 678
com.liferay.analytics.data.binding.impl [678]
  Unresolved requirement: Import-Package: com.fasterxml.jackson.annotation; version="[2.8.0,3.0.0)"
```